### PR TITLE
fix: wrong characters in tauri identifier

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pro PainT",
   "version": "0.1.0",
-  "identifier": "cz.muni.fi.pro_pain_t",
+  "identifier": "cz.muni.fi.pro-pain-t",
   "build": {
     "beforeBuildCommand": "cd pro-pain-t-app && trunk build --dist dist",
     "beforeDevCommand": "cd pro-pain-t-app && trunk serve --port 1420 --open",


### PR DESCRIPTION
```
Error The bundle identifier "cz.muni.fi.pro_pain_t" set in tauri.conf.json identifier.
The bundle identifier string must contain only alphanumeric characters (A-Z, a-z, and 0-9),
hyphens (-), and periods (.).
```